### PR TITLE
Add map rendering to world

### DIFF
--- a/src/Entity/Buildings/Building.h
+++ b/src/Entity/Buildings/Building.h
@@ -15,6 +15,7 @@ public:
     Building(Position2D position, std::string name) : Entity(position, std::move(name)) {}
     void Tick(ConsoleUI& ui) override;
     void showStatus(ConsoleUI& ui) const override;
+    char GetSymbol() const override { return 'B'; }
 private:
     int ticksAlive = 0;
 };

--- a/src/Entity/Entity.h
+++ b/src/Entity/Entity.h
@@ -20,6 +20,7 @@ public:
     virtual ~Entity() = default;
     virtual void Tick(ConsoleUI& ui) = 0;
     virtual void showStatus(ConsoleUI& ui) const = 0;
+    virtual char GetSymbol() const = 0;
     std::string GetName() {return name;};
     Position2D GetPosition() const { return position; }
     void SetPosition(Position2D position) { position = position; }

--- a/src/Entity/Units/Unit.h
+++ b/src/Entity/Units/Unit.h
@@ -15,6 +15,7 @@ public:
     Unit(Position2D position, std::string name) : Entity(position, std::move(name)) {}
     void showStatus(ConsoleUI& ui) const override;
     void Tick(ConsoleUI& ui) override;
+    char GetSymbol() const override { return 'U'; }
 private:
     int hunger = 0;
 };

--- a/src/Map/World.cpp
+++ b/src/Map/World.cpp
@@ -15,8 +15,24 @@ void World::Tick(ConsoleUI& ui) {
     for (auto& entity : entities) {
         entity->Tick(ui);
     }
+    Display(ui);
 }
 
 void World::AddEntity(std::shared_ptr<Entity> entity) {
     entities.push_back(entity);
+}
+
+void World::Display(ConsoleUI& ui) const {
+    std::vector<std::string> grid(height, std::string(width, '.'));
+    for (const auto& entity : entities) {
+        Position2D pos = entity->GetPosition();
+        if (pos.x >= 0 && pos.x < width && pos.y >= 0 && pos.y < height) {
+            grid[pos.y][pos.x] = entity->GetSymbol();
+        }
+    }
+
+    ui.log("Map:");
+    for (const auto& row : grid) {
+        ui.log(row);
+    }
 }

--- a/src/Map/World.h
+++ b/src/Map/World.h
@@ -15,6 +15,9 @@ class World {
 public:
     void Tick(ConsoleUI& ui);
     void AddEntity(std::shared_ptr<Entity> entity);
+    void Display(ConsoleUI& ui) const;
+    static constexpr int width = 20;
+    static constexpr int height = 10;
 private:
     int currentTick = 0;
     std::vector<std::shared_ptr<Entity>> entities;


### PR DESCRIPTION
## Summary
- add `GetSymbol` method in `Entity` interface
- implement symbol for `Unit` and `Building`
- extend `World` with fixed-size grid and new `Display` function
- print ASCII map each tick

## Testing
- `cmake ..` *(fails: CMake 3.31 or higher is required)*

------
https://chatgpt.com/codex/tasks/task_e_684729cc673c832a804f9eb89923c62e